### PR TITLE
fix `overlaps` boundary case + add pretty printing

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "TimeSpans"
 uuid = "bb34ddd2-327f-4c4a-bfb0-c98fc494ece1"
 authors = ["Beacon Biosignals, Inc."]
-version = "0.2.1"
+version = "0.2.2"
 
 [deps]
 Dates = "ade2ca70-3891-5945-98fb-dc099432e06a"

--- a/src/TimeSpans.jl
+++ b/src/TimeSpans.jl
@@ -42,6 +42,38 @@ Return `TimeSpan(start(x), stop(x))`.
 TimeSpan(x) = TimeSpan(start(x), stop(x))
 
 #####
+##### pretty printing
+#####
+
+function nanosecond_to_periods(ns::Integer)
+    μs, ns = divrem(ns, 1000)
+    ms, μs = divrem(μs, 1000)
+    s, ms = divrem(ms, 1000)
+    m, s = divrem(s, 60)
+    hr, m = divrem(m, 60)
+    return (hr, m, s, ms, μs, ns)
+end
+
+format_duration(t::Period) = format_duration(convert(Nanosecond, t).value)
+
+function format_duration(ns::Integer)
+    hr, m, s, ms, μs, ns = nanosecond_to_periods(ns)
+    hr = lpad(hr, 2, '0')
+    m = lpad(m, 2, '0')
+    s = lpad(s, 2, '0')
+    ms = lpad(ms, 3, '0')
+    μs = lpad(μs, 3, '0')
+    ns = lpad(ns, 3, '0')
+    return string(hr, ':', m, ':', s, '.', ms, μs, ns)
+end
+
+function Base.show(io::IO, w::TimeSpan)
+    start_string = format_duration(start(w))
+    stop_string = format_duration(stop(w))
+    return print(io, "TimeSpan(", start_string, ", ", stop_string, ')')
+end
+
+#####
 ##### generic TimeSpans.jl interface
 #####
 

--- a/src/TimeSpans.jl
+++ b/src/TimeSpans.jl
@@ -101,7 +101,7 @@ Return `true` if the timespan `a` and the timespan `b` overlap, return `false` o
 """
 function overlaps(a, b)
     starts_earlier, starts_later = ifelse(start(b) > start(a), (a, b), (b, a))
-    return stop(starts_earlier) >= start(starts_later)
+    return stop(starts_earlier) > start(starts_later)
 end
 
 """

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -45,8 +45,8 @@ end
     @test overlaps(TimeSpan(11, 20), TimeSpan(10, 19))
     @test overlaps(TimeSpan(10, 19), TimeSpan(10, 21))
     @test overlaps(TimeSpan(11, 19), TimeSpan(10, 20))
-    @test overlaps(TimeSpan(10, 20), TimeSpan(20, 30))
     @test overlaps(TimeSpan(20, 30), TimeSpan(10, 20))
+    @test !overlaps(TimeSpan(10, 20), TimeSpan(20, 30))
     @test !overlaps(TimeSpan(10, 20), TimeSpan(21, 30))
     @test !overlaps(TimeSpan(21, 30), TimeSpan(10, 20))
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -22,6 +22,7 @@ using TimeSpans: contains, nanoseconds_per_sample
     by = Second(rand(1:10))
     @test translate(t, by) === TimeSpan(start(t) + Nanosecond(by), stop(t) + Nanosecond(by))
     @test translate(t, -by) === TimeSpan(start(t) - Nanosecond(by), stop(t) - Nanosecond(by))
+    @test repr(TimeSpan(6149872364198, 123412345678910)) == "TimeSpan(01:42:29.872364198, 34:16:52.345678910)"
 end
 
 @testset "contains(::TimeSpan...)" begin

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -45,7 +45,7 @@ end
     @test overlaps(TimeSpan(11, 20), TimeSpan(10, 19))
     @test overlaps(TimeSpan(10, 19), TimeSpan(10, 21))
     @test overlaps(TimeSpan(11, 19), TimeSpan(10, 20))
-    @test overlaps(TimeSpan(20, 30), TimeSpan(10, 20))
+    @test !overlaps(TimeSpan(20, 30), TimeSpan(10, 20))
     @test !overlaps(TimeSpan(10, 20), TimeSpan(20, 30))
     @test !overlaps(TimeSpan(10, 20), TimeSpan(21, 30))
     @test !overlaps(TimeSpan(21, 30), TimeSpan(10, 20))


### PR DESCRIPTION
The conditional here was correct assuming an inclusive upper bound, but not an exclusive upper bound