### PR TITLE
Add method for `Base.in`

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "TimeSpans"
 uuid = "bb34ddd2-327f-4c4a-bfb0-c98fc494ece1"
 authors = ["Beacon Biosignals, Inc."]
-version = "0.2.2"
+version = "0.2.3"
 
 [deps]
 Dates = "ade2ca70-3891-5945-98fb-dc099432e06a"

--- a/src/TimeSpans.jl
+++ b/src/TimeSpans.jl
@@ -41,7 +41,7 @@ Return `TimeSpan(start(x), stop(x))`.
 """
 TimeSpan(x) = TimeSpan(start(x), stop(x))
 
-Base.in(x::TimePeriod, y::TimeSpan) = start(y) <= x <= stop(y)
+Base.in(x::TimePeriod, y::TimeSpan) = start(y) <= x < stop(y)
 
 # work around <https://github.com/JuliaLang/julia/issues/40311>:
 Base.findall(pred::Base.Fix2{typeof(in), TimeSpan}, obj::Union{Tuple, AbstractArray}) = invoke(findall, Tuple{Function, typeof(obj)}, pred, obj)

--- a/src/TimeSpans.jl
+++ b/src/TimeSpans.jl
@@ -41,6 +41,8 @@ Return `TimeSpan(start(x), stop(x))`.
 """
 TimeSpan(x) = TimeSpan(start(x), stop(x))
 
+Base.in(x::TimePeriod, y::TimeSpan) = start(y) <= x <= stop(y)
+
 #####
 ##### pretty printing
 #####

--- a/src/TimeSpans.jl
+++ b/src/TimeSpans.jl
@@ -43,6 +43,9 @@ TimeSpan(x) = TimeSpan(start(x), stop(x))
 
 Base.in(x::TimePeriod, y::TimeSpan) = start(y) <= x <= stop(y)
 
+# work around <https://github.com/JuliaLang/julia/issues/40311>:
+Base.findall(pred::Base.Fix2{typeof(in), TimeSpan}, obj::Union{Tuple, AbstractArray}) = invoke(findall, Tuple{Function, typeof(obj)}, pred, obj)
+
 #####
 ##### pretty printing
 #####

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -10,6 +10,9 @@ using TimeSpans: contains, nanoseconds_per_sample
     @test t == TimeSpan(start(t), start(t) + Nanosecond(1))
     @test contains(t, t)
     @test overlaps(t, t)
+    @test start(t) ∈ t
+    @test stop(t) ∈ t
+    @test stop(t) + Nanosecond(1) ∉ t
     @test shortest_timespan_containing([t]) == t
     @test shortest_timespan_containing((t,t,t)) == t
     @test duration(TimeSpan(start(t), stop(t) + Nanosecond(100))) == Nanosecond(101)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -82,3 +82,10 @@ end
         @test time_from_index(rate, i) == t
     end
 end
+
+@testset "`in` and `findall`" begin
+    @test findall(in(TimeSpan(1, 10)), Nanosecond.(5:15)) == 1:6
+    @test findall(in(TimeSpan(1, 10)), map(Nanosecond, (9,10,11))) == 1:2
+    @test in(TimeSpan(1,2))(Nanosecond(2))
+    @test !in(TimeSpan(1,2))(Nanosecond(3))
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -11,7 +11,7 @@ using TimeSpans: contains, nanoseconds_per_sample
     @test contains(t, t)
     @test overlaps(t, t)
     @test start(t) ∈ t
-    @test stop(t) ∈ t
+    @test !(stop(t) ∈ t)
     @test stop(t) + Nanosecond(1) ∉ t
     @test shortest_timespan_containing([t]) == t
     @test shortest_timespan_containing((t,t,t)) == t
@@ -84,8 +84,8 @@ end
 end
 
 @testset "`in` and `findall`" begin
-    @test findall(in(TimeSpan(1, 10)), Nanosecond.(5:15)) == 1:6
-    @test findall(in(TimeSpan(1, 10)), map(Nanosecond, (9,10,11))) == 1:2
-    @test in(TimeSpan(1,2))(Nanosecond(2))
-    @test !in(TimeSpan(1,2))(Nanosecond(3))
+    @test findall(in(TimeSpan(1, 10)), Nanosecond.(5:15)) == 1:5
+    @test findall(in(TimeSpan(1, 10)), map(Nanosecond, (9,10,11))) == 1:1
+    @test in(TimeSpan(1,2))(Nanosecond(1))
+    @test !in(TimeSpan(1,2))(Nanosecond(2))
 end


### PR DESCRIPTION
for the concrete `TimeSpan` object (not necessarily the generic interface, which I couldn't do without piracy). This allows things like:
```julia
julia> using TimeSpans, AxisKeys

julia> arr = KeyedArray(rand(20,1000), channel=1:20, time=Nanosecond.(Second.(1:1000)))
2-dimensional KeyedArray(NamedDimsArray(...)) with keys:
↓   channel ∈ 20-element UnitRange{Int64}
→   time ∈ 1000-element Vector{Nanosecond}
And data, 20×1000 Matrix{Float64}:
        Nanosecond(1000000000)    Nanosecond(2000000000)   …   Nanosecond(1000000000000) 
  (1)   0.601813                  0.11964                      0.683801
    ⋮                                                      ⋱   ⋮
 (19)   0.101305                  0.818797                     0.05417
 (20)   0.453637                  0.394128                     0.41232

julia> arr(time=in(TimeSpan(Minute(1), Minute(2))))
2-dimensional KeyedArray(NamedDimsArray(...)) with keys:
↓   channel ∈ 20-element UnitRange{Int64}
→   time ∈ 61-element view(::Vector{Nanosecond},...)
And data, 20×61 view(::Matrix{Float64}, :, [60, 61, 62, 63, 64, 65, 66, 67, 68, 69, 70, 71, 72, 73, 74, 75, 76, 77, 78, 79, 80, 81, 82, 83, 84, 85, 86, 87, 88, 89, 90, 91, 92, 93, 94, 95, 96, 97, 98, 99, 100, 101, 102, 103, 104, 105, 106, 107, 108, 109, 110, 111, 112, 113, 114, 115, 116, 117, 118, 119, 120]) with eltype Float64:
        Nanosecond(60000000000)    Nanosecond(61000000000)   …   Nanosecond(120000000000) 
  (1)   0.460153                   0.486687                      0.368666
    ⋮                                                        ⋱  
 (19)   0.469283                   0.921581                      0.298631
 (20)   0.0784988                  0.225722                      0.899711

```