### PR TITLE
Set operations and `rand` implementation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -132,3 +132,4 @@ Manifest.toml
 
 # misc
 *.DS_Store
+.vscode

--- a/Project.toml
+++ b/Project.toml
@@ -5,6 +5,7 @@ version = "0.2.3"
 
 [deps]
 Dates = "ade2ca70-3891-5945-98fb-dc099432e06a"
+Infiltrator = "5903a43b-9cc3-4c30-8d17-598619ec4e9b"
 Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 ResumableFunctions = "c5292f4c-5179-55e1-98c5-05642aab7184"
 StatsBase = "2913bbd2-ae8a-5f71-8c99-4fb6c76f3a91"

--- a/Project.toml
+++ b/Project.toml
@@ -5,6 +5,8 @@ version = "0.2.3"
 
 [deps]
 Dates = "ade2ca70-3891-5945-98fb-dc099432e06a"
+FGenerators = "4fd0377b-cfdc-4941-97f4-8d7ddbb8981e"
+StatsBase = "2913bbd2-ae8a-5f71-8c99-4fb6c76f3a91"
 
 [compat]
 julia = "1.0"

--- a/Project.toml
+++ b/Project.toml
@@ -5,9 +5,7 @@ version = "0.2.3"
 
 [deps]
 Dates = "ade2ca70-3891-5945-98fb-dc099432e06a"
-Infiltrator = "5903a43b-9cc3-4c30-8d17-598619ec4e9b"
 Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
-ResumableFunctions = "c5292f4c-5179-55e1-98c5-05642aab7184"
 StatsBase = "2913bbd2-ae8a-5f71-8c99-4fb6c76f3a91"
 
 [compat]

--- a/Project.toml
+++ b/Project.toml
@@ -5,10 +5,12 @@ version = "0.2.3"
 
 [deps]
 Dates = "ade2ca70-3891-5945-98fb-dc099432e06a"
-FGenerators = "4fd0377b-cfdc-4941-97f4-8d7ddbb8981e"
+Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
+ResumableFunctions = "c5292f4c-5179-55e1-98c5-05642aab7184"
 StatsBase = "2913bbd2-ae8a-5f71-8c99-4fb6c76f3a91"
 
 [compat]
+StatsBase = "0.33"
 julia = "1.0"
 
 [extras]

--- a/src/TimeSpans.jl
+++ b/src/TimeSpans.jl
@@ -4,7 +4,7 @@ using Dates, StatsBase, Random
 
 export TimeSpan, start, stop, istimespan, translate, overlaps,
        shortest_timespan_containing, duration, index_from_time, time_from_index,
-       extend, TimeSpanUnion, shrinkall!, translateall!, shrinkall, 
+       extend, TimeSpanUnion, shrinkall!, translateall!, shrinkall,
        translateall, TimeSpanUnion
 
 #####
@@ -559,8 +559,8 @@ function shrinkall!(x::TimeSpanUnion, by)
     if ispos(by)
         error("Expected a non-positive value")
     elseif ismultidim(by)
-        error("Shape of time spans and `by` could produce overlapping time "*
-            "spans. Call `collect` on the time spans first.")
+        error("Shape of time spans and `by` could produce overlapping time " *
+              "spans. Call `collect` on the time spans first.")
     else
         x.data .= extend.(x.data, by)
     end
@@ -597,11 +597,11 @@ end
 # internal implementation detail to make `mergesets` easier to implement).
 
 function translateall!(::TimeSpanUnion, by)
-    error("""The value of `by` is not a time period. It could be an aribtrary
-    iterable object and the passed value is a time union. Translating each value
-    in this time union by a different amount could lead to overlap. Call
-    `collect` on the time union first if you want to translate each time span by
-    a different value.""")
+    return error("""The value of `by` is not a time period. It could be an aribtrary
+           iterable object and the passed value is a time union. Translating each value
+           in this time union by a different amount could lead to overlap. Call
+           `collect` on the time union first if you want to translate each time span by
+           a different value.""")
 end
 
 """
@@ -630,7 +630,6 @@ Random.gentype(::TimeSpan) = Nanosecond
 
 function Random.Sampler(RNG::Type{<:Random.AbstractRNG}, x::TimeSpan,
                         ::Random.Repetition)
-
     sampler = Random.Sampler(RNG, (start(x).value):(stop(x).value - 1))
     return TimeSpanSampler(sampler)
 end

--- a/src/TimeSpans.jl
+++ b/src/TimeSpans.jl
@@ -544,25 +544,25 @@ end
 Base.copy(x::TimeSpanUnion) = TimeSpanUnion(copy(x.data), true, true)
 
 # some helper functions
-ispos(by::Period) = by > Nanosecond(0)
-ispos(xs) = all(x -> x > Nanosecond(0), xs)
+isneg(by::Period) = by < Nanosecond(0)
+isneg(xs) = all(x -> x < Nanosecond(0), xs)
 hasshape(by::Period) = false
 ismultidim(x) = Base.IteratorSize(x) isa Base.HasShape && length(size(x)) > 1
 
 """
     `shrinkall!(x::TimeSpanUnion, by)`
 
-Computes x .= extend.(x, by), throwing an error if it cannot be guaranteed that
+Computes x .= extend.(x, .-by), throwing an error if it cannot be guaranteed that
 the invariants of the time span union are maintained.
 """
 function shrinkall!(x::TimeSpanUnion, by)
-    if ispos(by)
-        error("Expected a non-positive value")
+    if isneg(by)
+        error("Expected a non-negative value")
     elseif ismultidim(by)
         error("Shape of time spans and `by` could produce overlapping time " *
               "spans. Call `collect` on the time spans first.")
     else
-        x.data .= extend.(x.data, by)
+        x.data .= extend.(x.data, .-by)
     end
 
     return x
@@ -571,9 +571,9 @@ end
 """
     `shrinkall!(x::AbstractVector{TimeSpan}, by)`
 
-Computes x .= extend.(x, by)
+Computes x .= extend.(x, .-by)
 """
-shrinkall!(x::AbstractVector{TimeSpan}, by) = x .= extend.(x, by)
+shrinkall!(x::AbstractVector{TimeSpan}, by) = x .= extend.(x, .-by)
 
 """
     `shrinkall(x, by)`

--- a/src/TimeSpans.jl
+++ b/src/TimeSpans.jl
@@ -385,7 +385,7 @@ function sorted_timespan_union(spans::AbstractVector)
     push!(result, spans[1])
     for span in @view(spans[2:end])
         if overlaps(result[end], span)
-            result[end] = TimeSpan(start(result[end]), stop(span))
+            result[end] = shortest_timespan_containing((result[end], span))
         else
             push!(result, span)
         end

--- a/src/TimeSpans.jl
+++ b/src/TimeSpans.jl
@@ -373,6 +373,8 @@ timeunion(data::TimeSpanUnion) = data
 # overlap between timespans
 function sorted_timespan_union(spans::AbstractVector)
     result = TimeSpan[]
+    isempty(spans) && return result
+
     sizehint!(result, length(spans))
     push!(result, spans[1])
     for span in @view(spans[2:end])
@@ -389,7 +391,7 @@ end
 function Base.reduce(::typeof(union), spans::AbstractVector{TimeSpan};
                      init=TimeSpan[])
     spans = timeunion(spans)
-    init = timeunion(spans)
+    init = timeunion(init)
     if isempty(init)
         return spans
     else
@@ -534,7 +536,7 @@ Random.gentype(::TimeSpan) = Nanosecond
 
 function Random.Sampler(RNG::Type{<:Random.AbstractRNG}, x::TimeSpan,
                         ::Random.Repetition)
-                        
+
     sampler = Random.Sampler(RNG, (start(x).value):(stop(x).value - 1))
     return TimeSpanSampler(sample)
 end

--- a/src/TimeSpans.jl
+++ b/src/TimeSpans.jl
@@ -4,8 +4,8 @@ using Dates, StatsBase, Random
 
 export TimeSpan, start, stop, istimespan, translate, overlaps,
        shortest_timespan_containing, duration, index_from_time, time_from_index,
-       extend, TimeSpanUnion, shrinkall!, translateall!, shrinkall,
-       translateall
+       extend, TimeSpanUnion, shrink_all!, translate_all!, shrink_all,
+       translate_all
 
 #####
 ##### `TimeSpan`
@@ -346,7 +346,7 @@ Using this type helps to ensure that sequences of multiple set operations do not
 have to repeatedly check and preserve these invariants.
 
 If you need to modify these sets yourself you can use one of the invariant
-preserving methods (`shrinkall!`, `translateall!`, etc...) or you can call
+preserving methods (`shrink_all!`, `translate_all!`, etc...) or you can call
 `collect` and modify the resulting copy. Future calls to set operations
 will have to re-establish the invariants of such a copy.
 """
@@ -542,12 +542,12 @@ hasshape(by::Period) = false
 ismultidim(x) = Base.IteratorSize(x) isa Base.HasShape && length(size(x)) > 1
 
 """
-    `shrinkall!(x::TimeSpanUnion, by)`
+    `shrink_all!(x::TimeSpanUnion, by)`
 
 Computes x .= extend.(x, .-by), throwing an error if it cannot be guaranteed that
 the invariants of the time span union are maintained.
 """
-function shrinkall!(x::TimeSpanUnion, by)
+function shrink_all!(x::TimeSpanUnion, by)
     if isneg(by)
         error("Expected a non-negative value")
     elseif ismultidim(by)
@@ -561,26 +561,26 @@ function shrinkall!(x::TimeSpanUnion, by)
 end
 
 """
-    `shrinkall!(x::AbstractVector{TimeSpan}, by)`
+    `shrink_all!(x::AbstractVector{TimeSpan}, by)`
 
 Computes x .= extend.(x, .-by)
 """
-shrinkall!(x::AbstractVector{TimeSpan}, by) = x .= extend.(x, .-by)
+shrink_all!(x::AbstractVector{TimeSpan}, by) = x .= extend.(x, .-by)
 
 """
-    `shrinkall(x, by)`
+    `shrink_all(x, by)`
 
-Calls `shrinkall!(copy(x), by)`.
+Calls `shrink_all!(copy(x), by)`.
 """
-shrinkall(x, by) = shrinkall!(copy(x), by)
+shrink_all(x, by) = shrink_all!(copy(x), by)
 
 """
-    `translateall!(x::TimeSpanUnion, by)`
+    `translate_all!(x::TimeSpanUnion, by)`
 
 Computes x .= translate.(x, by), throwing an error if it cannot be guaranteed that
 the invariants of the time span union are maintained. 
 """
-function translateall!(x::TimeSpanUnion, by::Period)
+function translate_all!(x::TimeSpanUnion, by::Period)
     x.data .= translate.(x.data, by)
     return x
 end
@@ -588,7 +588,7 @@ end
 # never be returned by any of the set-related methods (they are purely an
 # internal implementation detail to make `mergesets` easier to implement).
 
-function translateall!(::TimeSpanUnion, by)
+function translate_all!(::TimeSpanUnion, by)
     return error("""The value of `by` is not a time period. It could be an aribtrary
            iterable object and the passed value is a time union. Translating each value
            in this time union by a different amount could lead to overlap. Call
@@ -597,18 +597,18 @@ function translateall!(::TimeSpanUnion, by)
 end
 
 """
-    `translateall!(x::AbstractVector{TimeSpan}, by)`
+    `translate_all!(x::AbstractVector{TimeSpan}, by)`
 
 Computes x .= translate.(x, by)
 """
-translateall!(x::AbstractVector{TimeSpan}, by) = x .= translate.(x, by)
+translate_all!(x::AbstractVector{TimeSpan}, by) = x .= translate.(x, by)
 
 """
-    `translateall(x, by)`
+    `translate_all(x, by)`
 
-Calls `translateall!(copy(x), by)`
+Calls `translate_all!(copy(x), by)`
 """
-translateall(x, by) = translateall!(copy(x), by)
+translate_all(x, by) = translate_all!(copy(x), by)
 
 #####
 ##### Sampling from time spans 

--- a/src/TimeSpans.jl
+++ b/src/TimeSpans.jl
@@ -632,7 +632,7 @@ function Random.Sampler(RNG::Type{<:Random.AbstractRNG}, x::TimeSpan,
                         ::Random.Repetition)
 
     sampler = Random.Sampler(RNG, (start(x).value):(stop(x).value - 1))
-    return TimeSpanSampler(sample)
+    return TimeSpanSampler(sampler)
 end
 function Base.rand(rng::Random.AbstractRNG, x::TimeSpanSampler)
     return Nanosecond(rand(rng, x.sampler))

--- a/src/TimeSpans.jl
+++ b/src/TimeSpans.jl
@@ -357,10 +357,10 @@ calls to set operations will have to re-establish the invariants of such a copy.
 """
 struct TimeSpanUnion{A} <: AbstractTimeSpanUnion
     data::A
-    function TimeSpanUnion(x::AbstractVector{TimeSpan}, issorted=false,
-                           nooverlap=false)
-        sorted = issorted ? x : sort(x; by=start)
-        merged = nooverlap ? sorted : sorted_timespan_union(sorted)
+    function TimeSpanUnion(x::AbstractVector{TimeSpan}; is_sorted=false,
+                           may_overlap=true)
+        sorted = is_sorted ? x : sort(x; by=start)
+        merged = may_overlap ? sorted_timespan_union(sorted) : sorted
         return new{typeof(merged)}(merged)
     end
 end
@@ -530,14 +530,16 @@ function mergesets(op, x::AbstractTimeSpanUnion, y::AbstractTimeSpanUnion)
         end
     end
 
-    return TimeSpanUnion(result, true, true)
+    return TimeSpanUnion(result, is_sorted=true, may_overlap=false)
 end
 
 #####
 ##### Invariant preserving operations over TimeSpanUnions 
 #####
 
-Base.copy(x::TimeSpanUnion) = TimeSpanUnion(copy(x.data), true, true)
+function Base.copy(x::TimeSpanUnion)
+    TimeSpanUnion(copy(x.data), is_sorted=true, may_overlap=false)
+end
 
 # some helper functions
 isneg(by::Period) = by < Nanosecond(0)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -133,26 +133,26 @@ end
     # whitebox testing of the internal, `timeunion` function
     x = reduce(union, spans[2:end], init = spans[1]) 
     @test all(x .== TimeSpans.timeunion(spans))
-    @test_throws ErrorException x[1] = TimeSpan(Nanosecond(0), Nanosecond(1))
+    @test_throws TimeSpans.ReadOnlyArrayError x[1] = TimeSpan(Nanosecond(0), Nanosecond(1))
     span = TimeSpans.timeunion(spans[1])
-    @test_throws ErrorException span[] = TimeSpan(Nanosecond(0), Nanosecond(1))
+    @test_throws TimeSpans.ReadOnlyArrayError span[] = TimeSpan(Nanosecond(0), Nanosecond(1))
 
     # test invariant preserving operations on unions
     x = reduce(union, spans[1:25])
-    xext = shrinkall(x, Nanosecond(1))
-    @test_throws ErrorException xext[1] = TimeSpan(Nanosecond(0), Nanosecond(1))
-    @test_throws ErrorException shrinkall(x, Nanosecond(-1))
+    xext = shrink_all(x, Nanosecond(1))
+    @test_throws TimeSpans.ReadOnlyArrayError xext[1] = TimeSpan(Nanosecond(0), Nanosecond(1))
+    @test_throws TimeSpans.ArgumentError shrink_all(x, Nanosecond(-1))
 
-    xext = shrinkall(x, Nanosecond.(rand(1:5, length(x))))
-    @test_throws ErrorException xext[1] = TimeSpan(Nanosecond(0), Nanosecond(1))
-    @test_throws ErrorException shrinkall(x, Nanosecond.(rand(.-(1:5), length(x))))
-    @test length(shrinkall(collect(x), Nanosecond.(rand(.-(1:5), length(x))))) ==
+    xext = shrink_all(x, Nanosecond.(rand(1:5, length(x))))
+    @test_throws TimeSpans.ReadOnlyArrayError xext[1] = TimeSpan(Nanosecond(0), Nanosecond(1))
+    @test_throws TimeSpans.ArgumentError shrink_all(x, Nanosecond.(rand(.-(1:5), length(x))))
+    @test length(shrink_all(collect(x), Nanosecond.(rand(.-(1:5), length(x))))) ==
         length(x)
 
-    xtrans = translateall(x, Nanosecond(5))
-    @test_throws ErrorException xtrans[1] = TimeSpan(Nanosecond(0), Nanosecond(1))
-    @test_throws ErrorException translateall(x, Nanosecond.(rand(1:5, length(x))))
-    @test length(translateall(collect(x), Nanosecond.(rand(1:5, length(x))))) ==
+    xtrans = translate_all(x, Nanosecond(5))
+    @test_throws TimeSpans.ReadOnlyArrayError xtrans[1] = TimeSpan(Nanosecond(0), Nanosecond(1))
+    @test_throws TimeSpans.ArgumentError translate_all(x, Nanosecond.(rand(1:5, length(x))))
+    @test length(translate_all(collect(x), Nanosecond.(rand(1:5, length(x))))) ==
         length(x)
 end
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -131,6 +131,10 @@ end
     testsets(spans[1], spans[26:end])
     testsets(spans[1:25], spans[26])
 
+    # verify that `stop` need not be ordered
+    spans = [TimeSpan(Nanosecond(0), Nanosecond(5)), TimeSpan(Nanosecond(0), Nanosecond(3))]
+    @test shortest_timespan_containing(union(spans)) == TimeSpan(Nanosecond(0), Nanosecond(5))
+
     # whitebox testing of the internal, `time_union` function
     x = reduce(union, spans[2:end], init = spans[1]) 
     @test all(x .== TimeSpans.time_union(spans))

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -139,14 +139,14 @@ end
 
     # test invariant preserving operations on unions
     x = reduce(union, spans[1:25])
-    xext = shrinkall(x, Nanosecond(-1))
+    xext = shrinkall(x, Nanosecond(1))
     @test_throws ErrorException xext[1] = TimeSpan(Nanosecond(0), Nanosecond(1))
-    @test_throws ErrorException shrinkall(x, Nanosecond(1))
+    @test_throws ErrorException shrinkall(x, Nanosecond(-1))
 
-    xext = shrinkall(x, Nanosecond.(rand(.-(1:5), length(x))))
+    xext = shrinkall(x, Nanosecond.(rand(1:5, length(x))))
     @test_throws ErrorException xext[1] = TimeSpan(Nanosecond(0), Nanosecond(1))
-    @test_throws ErrorException shrinkall(x, Nanosecond.(rand(1:5, length(x))))
-    @test length(shrinkall(collect(x), Nanosecond.(rand(1:5, length(x))))) ==
+    @test_throws ErrorException shrinkall(x, Nanosecond.(rand(.-(1:5), length(x))))
+    @test length(shrinkall(collect(x), Nanosecond.(rand(.-(1:5), length(x))))) ==
         length(x)
 
     xtrans = translateall(x, Nanosecond(5))

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -27,6 +27,7 @@ using TimeSpans: contains, nanoseconds_per_sample
     @test translate(t, -by) === TimeSpan(start(t) - Nanosecond(by), stop(t) - Nanosecond(by))
     @test extend(t, by) === TimeSpan(start(t), max(start(t), stop(t) + Nanosecond(by)))
     @test extend(t, -by) === TimeSpan(start(t), max(start(t), stop(t) - Nanosecond(by)))
+    @test extend(t, -(duration(t) + Nanosecond(1))) === TimeSpan(start(t), max(start(t), stop(t) - Nanosecond(by)))
     @test repr(TimeSpan(6149872364198, 123412345678910)) == "TimeSpan(01:42:29.872364198, 34:16:52.345678910)"
 end
 
@@ -130,11 +131,11 @@ end
     testsets(spans[1], spans[26:end])
     testsets(spans[1:25], spans[26])
 
-    # whitebox testing of the internal, `timeunion` function
+    # whitebox testing of the internal, `time_union` function
     x = reduce(union, spans[2:end], init = spans[1]) 
-    @test all(x .== TimeSpans.timeunion(spans))
+    @test all(x .== TimeSpans.time_union(spans))
     @test_throws TimeSpans.ReadOnlyArrayError x[1] = TimeSpan(Nanosecond(0), Nanosecond(1))
-    span = TimeSpans.timeunion(spans[1])
+    span = TimeSpans.time_union(spans[1])
     @test_throws TimeSpans.ReadOnlyArrayError span[] = TimeSpan(Nanosecond(0), Nanosecond(1))
 
     # test invariant preserving operations on unions

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -95,7 +95,7 @@ end
 @testset "Set operations: (e.g. `intersect`, `union`, `setdiff`)" begin
     
     myduration(x::TimeSpan) = duration(x)
-    myduration(x::AbstractVector{TimeSpan}) = sum(duration, x, init = Nanosecond(0))
+    myduration(x::AbstractVector{TimeSpan}) = reduce(+, map(duration, x), init = Nanosecond(0))
     myunion(x::TimeSpan) = x
     myunion(x::AbstractVector{TimeSpan}) = reduce(∪, x)
     function testsets(a, b)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -136,6 +136,24 @@ end
     @test_throws ErrorException x[1] = TimeSpan(Nanosecond(0), Nanosecond(1))
     span = TimeSpans.timeunion(spans[1])
     @test_throws ErrorException span[] = TimeSpan(Nanosecond(0), Nanosecond(1))
+
+    # test invariant preserving operations on unions
+    x = reduce(union, spans[1:25])
+    xext = shrinkall(x, Nanosecond(-1))
+    @test_throws ErrorException xext[1] = TimeSpan(Nanosecond(0), Nanosecond(1))
+    @test_throws ErrorException shrinkall(x, Nanosecond(1))
+
+    xext = shrinkall(x, Nanosecond.(rand(.-(1:5), length(x))))
+    @test_throws ErrorException xext[1] = TimeSpan(Nanosecond(0), Nanosecond(1))
+    @test_throws ErrorException shrinkall(x, Nanosecond.(rand(1:5, length(x))))
+    @test length(shrinkall(collect(x), Nanosecond.(rand(1:5, length(x))))) ==
+        length(x)
+
+    xtrans = translateall(x, Nanosecond(5))
+    @test_throws ErrorException xtrans[1] = TimeSpan(Nanosecond(0), Nanosecond(1))
+    @test_throws ErrorException translateall(x, Nanosecond.(rand(1:5, length(x))))
+    @test length(translateall(collect(x), Nanosecond.(rand(1:5, length(x))))) ==
+        length(x)
 end
 
 @testset "`rand` methods over `TimeSpan` and vectors of it." begin

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -118,10 +118,10 @@ end
     testsets(spans[1:25], spans[26:end])
     testsets(spans[1], spans[26:end])
     testsets(spans[1:25], spans[26])
-    start(starts[1]) ∈ spans
+    @test start(starts[1]) ∈ spans
 
     # whitebox testing of the internal, `timeunion` function
-    x = reduce(union, spans[2:end], spans[1]) 
+    x = reduce(union, spans[2:end], init = spans[1]) 
     @test x == TimeSpans.timeunion(spans)
     @test_throws ErrorException x[1] = TimeSpan(Nanosecond(0), Nanosecond(1))
     span = TimeSpans.timeunion(spans[1])
@@ -129,7 +129,7 @@ end
 end
 
 @testset "`rand` methods over `TimeSpan` and vectors of it." begin
-    starts = rand(1:100_000, 50)
+    starts = Nanosecond.(rand(1:100_000, 50))
     spans = TimeSpan.(starts, starts .+ Nanosecond(rand(1:10_000)))
     @test all(t ∈ spans for t in rand(spans, 20))
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -122,6 +122,10 @@ end
     testsets(spans[1], spans[4:end])
     testsets(spans[1:3], spans[4])
 
+    # verify that `stop` need not be ordered
+    spans = [TimeSpan(Nanosecond(0), Nanosecond(5)), TimeSpan(Nanosecond(0), Nanosecond(3))]
+    @test shortest_timespan_containing(union(spans)) == TimeSpan(Nanosecond(0), Nanosecond(5))
+
     starts = Nanosecond.(rand(1:100_000, 25))
     spans = TimeSpan.(starts, starts .+ Nanosecond.(rand(1:10_000)))
     spans = [spans; translate.(spans, Nanosecond.(round.(Int, getproperty.(duration.(spans), :value) .* (2.0.*rand(length(spans)) .- 1.0))))]
@@ -130,10 +134,6 @@ end
     testsets(spans[1:25], spans[26:end])
     testsets(spans[1], spans[26:end])
     testsets(spans[1:25], spans[26])
-
-    # verify that `stop` need not be ordered
-    spans = [TimeSpan(Nanosecond(0), Nanosecond(5)), TimeSpan(Nanosecond(0), Nanosecond(3))]
-    @test shortest_timespan_containing(union(spans)) == TimeSpan(Nanosecond(0), Nanosecond(5))
 
     # whitebox testing of the internal, `time_union` function
     x = reduce(union, spans[2:end], init = spans[1]) 


### PR DESCRIPTION
These changes set up some functionality I'm using to generate null annotation labels: e.g. to sample regions of data that have no annotation.

~~This is still in draft form, working on defining some tests...~~

* add support for `Base` functions `union`, `intersect` and `setdiff`, etc...
* add a type, `TimeSpanUnion` to establish and maintain invariants on the output of set operations; these are read-only arrays of TimeSpans
* ~~add `Base.in` method~~ (already exists)
* add support for `Base.rand` over `TimeSpan` and `TimeSpanUnion` types.
* adds an `extend` method to adjust the endpoint of a `TimeSpan`.
* add invariant preserving operations `translateall(!)` and `shrinkall(!)` over `TimeSpanUnion` objects.