### PR TITLE
Make `TimeSpan` a subtype of `AbstractInterval`

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -5,6 +5,7 @@ version = "0.2.3"
 
 [deps]
 Dates = "ade2ca70-3891-5945-98fb-dc099432e06a"
+Intervals = "d8418881-c3e1-53bb-8760-2df7ec849ed5"
 
 [compat]
 julia = "1.0"

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -26,6 +26,7 @@ using TimeSpans: contains, nanoseconds_per_sample
     @test translate(t, by) === TimeSpan(start(t) + Nanosecond(by), stop(t) + Nanosecond(by))
     @test translate(t, -by) === TimeSpan(start(t) - Nanosecond(by), stop(t) - Nanosecond(by))
     @test repr(TimeSpan(6149872364198, 123412345678910)) == "TimeSpan(01:42:29.872364198, 34:16:52.345678910)"
+    @test TimeSpan(Microsecond(1) + Nanosecond(1)) == TimeSpan(Nanosecond(1001))
 end
 
 @testset "contains(::TimeSpan...)" begin
@@ -62,6 +63,8 @@ end
     @test shortest_timespan_containing([TimeSpan(3, 7),
                                         TimeSpan(1, 10),
                                         TimeSpan(2, 5)]) == TimeSpan(1, 10)
+
+    @test_throws MethodError shortest_timespan_containing(TimeSpan(1, 2))
 end
 
 @testset "time <--> index conversion" begin


### PR DESCRIPTION
A good intermediate step to switching over to Intervals.jl completely. Makes the `TimeSpan` type a subtype of `AbstractInterval{Nanosecond,Closed,Open}` and implements functionality using Intervals functions.

Main things to do here:
- [ ] Update generic `AbstractInterval` functions to return `TimeSpan` instead of `Interval`. Changing this will probably require some formalizing of the intervals interface
- [ ] Add deprecations for no longer needed TimeSpan functions
- [ ] Upstream changes that belong elsewhere