### PR TITLE
Improve accuracy of `index_from_time`

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "TimeSpans"
 uuid = "bb34ddd2-327f-4c4a-bfb0-c98fc494ece1"
 authors = ["Beacon Biosignals, Inc."]
-version = "0.2.3"
+version = "0.2.4"
 
 [deps]
 Dates = "ade2ca70-3891-5945-98fb-dc099432e06a"

--- a/src/TimeSpans.jl
+++ b/src/TimeSpans.jl
@@ -7,7 +7,7 @@ export TimeSpan, start, stop, istimespan, translate, overlaps,
        time_from_index
 
 
-const NS_IN_SEC = 1_000_000_000  # Number of nanoseconds in one second
+const NS_IN_SEC = Dates.value(Nanosecond(Second(1)))  # Number of nanoseconds in one second
 
 #####
 ##### `TimeSpan`

--- a/src/TimeSpans.jl
+++ b/src/TimeSpans.jl
@@ -7,6 +7,8 @@ export TimeSpan, start, stop, istimespan, translate, overlaps,
        time_from_index
 
 
+const NS_IN_SEC = 1_000_000_000  # Number of nanoseconds in one second
+
 #####
 ##### `TimeSpan`
 #####
@@ -171,7 +173,7 @@ duration(span) = stop(span) - start(span)
 
 Given `sample_rate` in Hz, return the number of nanoseconds corresponding to one sample.
 """
-nanoseconds_per_sample(sample_rate) = inv(sample_rate) * 1_000_000_000
+nanoseconds_per_sample(sample_rate) = inv(sample_rate) * NS_IN_SEC
 
 """
     index_from_time(sample_rate, sample_time::Period)
@@ -199,8 +201,8 @@ julia> index_from_time(100, Millisecond(1000))
 function index_from_time(sample_rate, sample_time::Period)
     time_in_nanoseconds = convert(Nanosecond, sample_time).value
     time_in_nanoseconds >= 0 || throw(ArgumentError("`sample_time` must be >= 0 nanoseconds"))
-    ns_per_sample = nanoseconds_per_sample(sample_rate)
-    return floor(Int, time_in_nanoseconds / ns_per_sample) + 1
+    time_in_seconds = time_in_nanoseconds / NS_IN_SEC
+    return floor(Int, time_in_seconds * sample_rate) + 1
 end
 
 """

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -94,3 +94,19 @@ end
     @test in(TimeSpan(1,2))(Nanosecond(1))
     @test !in(TimeSpan(1,2))(Nanosecond(2))
 end
+
+@testset "index_from_time" begin
+    @testset "docstring" begin
+        @test index_from_time(1, Second(0)) == 1
+        @test index_from_time(1, Second(1)) == 2
+        @test index_from_time(100, Millisecond(999)) == 100
+        @test index_from_time(100, Millisecond(1000)) == 101
+    end
+
+    @testset "floating-point precision" begin
+        ns = Nanosecond((2 * 60 + 30) * 1e9)
+        @test index_from_time(200, ns) == 30001
+        @test index_from_time(200e0, ns) == 30001
+        @test index_from_time(200f0, ns) == 30001
+    end
+end


### PR DESCRIPTION
Fixes https://github.com/beacon-biosignals/TimeSpans.jl/issues/15