### PR TITLE
Add parse support for `TimeSpan`

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "TimeSpans"
 uuid = "bb34ddd2-327f-4c4a-bfb0-c98fc494ece1"
 authors = ["Beacon Biosignals, Inc."]
-version = "0.2.4"
+version = "0.2.5"
 
 [deps]
 Dates = "ade2ca70-3891-5945-98fb-dc099432e06a"

--- a/src/TimeSpans.jl
+++ b/src/TimeSpans.jl
@@ -43,7 +43,12 @@ Return `TimeSpan(start(x), stop(x))`.
 """
 TimeSpan(x) = TimeSpan(start(x), stop(x))
 
-function Base.parse(::Type{TimeSpan}, str::AbstractString)
+"""
+    pqparse(::Type{TimeSpan}, str::AbstractString) -> TimeSpan
+
+Parse value of type `TimeSpan` from the output format used by PostresSQL.
+"""
+function pqparse(::Type{TimeSpan}, str::AbstractString)
     if !startswith(str, '[')
         throw(ArgumentError("Expected `TimeSpan` string to start with '[', instead found: \"$str\""))
     elseif !endswith(str, ')')

--- a/src/TimeSpans.jl
+++ b/src/TimeSpans.jl
@@ -43,6 +43,17 @@ Return `TimeSpan(start(x), stop(x))`.
 """
 TimeSpan(x) = TimeSpan(start(x), stop(x))
 
+function Base.parse(::Type{TimeSpan}, str::AbstractString)
+    if !startswith(str, '[')
+        throw(ArgumentError("Expected `TimeSpan` string to start with '[', instead found: \"$str\""))
+    elseif !endswith(str, ')')
+        throw(ArgumentError("Expected `TimeSpan` string to end with ')', instead found: \"$str\""))
+    end
+    start_str, stop_str = split(str[2:(end - 1)], ','; limit=2)
+    start, stop = parse(Int, start_str), parse(Int, stop_str)
+    return TimeSpan(start, stop)
+end
+
 Base.in(x::TimePeriod, y::TimeSpan) = start(y) <= x < stop(y)
 
 # work around <https://github.com/JuliaLang/julia/issues/40311>:

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -28,17 +28,17 @@ using TimeSpans: contains, nanoseconds_per_sample
     @test repr(TimeSpan(6149872364198, 123412345678910)) == "TimeSpan(01:42:29.872364198, 34:16:52.345678910)"
 end
 
-@testset "parse" begin
+@testset "pqparse" begin
     # Missing inclusive decorators
-    @test_throws ArgumentError parse(TimeSpan, "")
-    @test_throws ArgumentError parse(TimeSpan, "[")
-    @test_throws ArgumentError parse(TimeSpan, ")")
+    @test_throws ArgumentError TimeSpans.pqparse(TimeSpan, "")
+    @test_throws ArgumentError TimeSpans.pqparse(TimeSpan, "[")
+    @test_throws ArgumentError TimeSpans.pqparse(TimeSpan, ")")
 
     # Invalid digits
-    @test_throws ArgumentError parse(TimeSpan, "[1,2,3)")
-    @test_throws ArgumentError parse(TimeSpan, "[1,b)")
+    @test_throws ArgumentError TimeSpans.pqparse(TimeSpan, "[1,2,3)")
+    @test_throws ArgumentError TimeSpans.pqparse(TimeSpan, "[1,b)")
 
-    @test parse(TimeSpan, "[1,2)") == TimeSpan(1, 2)
+    @test TimeSpans.pqparse(TimeSpan, "[1,2)") == TimeSpan(1, 2)
 end
 
 @testset "format_duration" begin

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -28,6 +28,19 @@ using TimeSpans: contains, nanoseconds_per_sample
     @test repr(TimeSpan(6149872364198, 123412345678910)) == "TimeSpan(01:42:29.872364198, 34:16:52.345678910)"
 end
 
+@testset "parse" begin
+    # Missing inclusive decorators
+    @test_throws ArgumentError parse(TimeSpan, "")
+    @test_throws ArgumentError parse(TimeSpan, "[")
+    @test_throws ArgumentError parse(TimeSpan, ")")
+
+    # Invalid digits
+    @test_throws ArgumentError parse(TimeSpan, "[1,2,3)")
+    @test_throws ArgumentError parse(TimeSpan, "[1,b)")
+
+    @test parse(TimeSpan, "[1,2)") == TimeSpan(1, 2)
+end
+
 @testset "format_duration" begin
     @test TimeSpans.format_duration(3723004005006) == "01:02:03.004005006"
     @test TimeSpans.format_duration(-3723004005006) == "-01:02:03.004005006"


### PR DESCRIPTION
Added to avoid type-piracy in internal beacon code. I could have gone further and supported parsing the format duration as well but that can always be added in later.