### PR TITLE
Add functionality to merge timespans in collections

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "TimeSpans"
 uuid = "bb34ddd2-327f-4c4a-bfb0-c98fc494ece1"
 authors = ["Beacon Biosignals, Inc."]
-version = "0.2.4"
+version = "0.2.5"
 
 [deps]
 Dates = "ade2ca70-3891-5945-98fb-dc099432e06a"

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -15,5 +15,6 @@ TimeSpans.duration
 TimeSpans.translate
 TimeSpans.time_from_index
 TimeSpans.index_from_time
+TimeSpans.merge_spans
 TimeSpans.merge_spans!
 ```

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -15,4 +15,5 @@ TimeSpans.duration
 TimeSpans.translate
 TimeSpans.time_from_index
 TimeSpans.index_from_time
+TimeSpans.merge_spans!
 ```

--- a/src/TimeSpans.jl
+++ b/src/TimeSpans.jl
@@ -4,7 +4,7 @@ using Dates
 
 export TimeSpan, start, stop, istimespan, translate, overlaps,
        shortest_timespan_containing, duration, index_from_time,
-       time_from_index
+       time_from_index, merge_spans!
 
 
 const NS_IN_SEC = Dates.value(Nanosecond(Second(1)))  # Number of nanoseconds in one second
@@ -283,6 +283,53 @@ function time_from_index(sample_rate, sample_range::AbstractUnitRange)
     j = j == i ? j : j + 1
     return TimeSpan(time_from_index(sample_rate, i),
                     time_from_index(sample_rate, j))
+end
+
+"""
+    merge_spans!(predicate, spans)
+
+Given a mutable, indexable iterator of timespans and a function to compare two
+time-sequential timespans, return the iterator in sorted order with all pairs for
+which `predicate` returns `true` merged via [`shortest_timespan_containing`](@ref).
+
+```jldoctest
+julia> spans = [TimeSpan(0, 10), TimeSpan(6, 12), TimeSpan(15, 20),
+                TimeSpan(21, 30), TimeSpan(29, 31)]
+5-element Vector{TimeSpan}:
+ TimeSpan(00:00:00.000000000, 00:00:00.000000010)
+ TimeSpan(00:00:00.000000006, 00:00:00.000000012)
+ TimeSpan(00:00:00.000000015, 00:00:00.000000020)
+ TimeSpan(00:00:00.000000021, 00:00:00.000000030)
+ TimeSpan(00:00:00.000000029, 00:00:00.000000031)
+
+julia> merge_spans!(overlaps, spans)
+3-element Vector{TimeSpan}:
+ TimeSpan(00:00:00.000000000, 00:00:00.000000012)
+ TimeSpan(00:00:00.000000015, 00:00:00.000000020)
+ TimeSpan(00:00:00.000000021, 00:00:00.000000031)
+
+julia> merge_spans!((a, b) -> start(b) - stop(a) < Nanosecond(5), spans)
+1-element Vector{TimeSpan}:
+ TimeSpan(00:00:00.000000000, 00:00:00.000000031)
+```
+"""
+function merge_spans!(predicate, spans)
+    length(spans) <= 1 && return spans
+    sort!(spans; by=start)
+    merged_indices = Int[]
+    merge_target_index = firstindex(spans)
+    for i in Iterators.drop(eachindex(spans), 1)
+        target = spans[merge_target_index]
+        current = spans[i]
+        if predicate(target, current)
+            spans[merge_target_index] = shortest_timespan_containing(target, current)
+            push!(merged_indices, i)
+        else
+            merge_target_index = i
+        end
+    end
+    deleteat!(spans, merged_indices)
+    return spans
 end
 
 end # module

--- a/src/TimeSpans.jl
+++ b/src/TimeSpans.jl
@@ -4,7 +4,7 @@ using Dates
 
 export TimeSpan, start, stop, istimespan, translate, overlaps,
        shortest_timespan_containing, duration, index_from_time,
-       time_from_index, merge_spans!
+       time_from_index, merge_spans!, merge_spans
 
 
 const NS_IN_SEC = Dates.value(Nanosecond(Second(1)))  # Number of nanoseconds in one second
@@ -331,5 +331,14 @@ function merge_spans!(predicate, spans)
     deleteat!(spans, merged_indices)
     return spans
 end
+
+"""
+    merge_spans(predicate, spans)
+
+Return `merge_spans!(predicate, collect(spans))`.
+
+See also [`merge_spans!`](@ref).
+"""
+merge_spans(predicate, spans) = merge_spans!(predicate, collect(spans))
 
 end # module

--- a/src/TimeSpans.jl
+++ b/src/TimeSpans.jl
@@ -162,6 +162,13 @@ function shortest_timespan_containing(spans)
 end
 
 """
+    shortest_timespan_containing(a, b)
+
+Return the shortest possible `TimeSpan` containing the timespans `a` and `b`.
+"""
+shortest_timespan_containing(a, b) = TimeSpan(min(start(a), start(b)), max(stop(a), stop(b)))
+
+"""
     duration(span)
 
 Return `stop(span) - start(span)`.

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -113,3 +113,17 @@ end
         @test index_from_time(200f0, ns) == 30001
     end
 end
+
+@testset "merge_spans!" begin
+    spans = [TimeSpan(0, 10), TimeSpan(6, 12), TimeSpan(15, 20),
+             TimeSpan(21, 30), TimeSpan(29, 31)]
+    merge_spans!(overlaps, spans)
+    @test spans == [TimeSpan(0, 12), TimeSpan(15, 20), TimeSpan(21, 31)]
+    # No-op when the predicate is never `true`
+    merge_spans!(overlaps, spans)
+    @test spans == [TimeSpan(0, 12), TimeSpan(15, 20), TimeSpan(21, 31)]
+    merge_spans!((a, b) -> true, spans)
+    @test spans == [TimeSpan(0, 31)]
+    @test merge_spans!((a, b) -> rand(Bool), TimeSpan[]) == TimeSpan[]
+    @test merge_spans!((a, b) -> rand(Bool), [TimeSpan(0, 1)]) == [TimeSpan(0, 1)]
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -127,3 +127,10 @@ end
     @test merge_spans!((a, b) -> rand(Bool), TimeSpan[]) == TimeSpan[]
     @test merge_spans!((a, b) -> rand(Bool), [TimeSpan(0, 1)]) == [TimeSpan(0, 1)]
 end
+
+@testset "merge_spans" begin
+    @test merge_spans((a, b) -> start(b) - stop(a) < Nanosecond(5),
+                      (TimeSpan(0, 1), TimeSpan(4, 10))) == [TimeSpan(0, 10)]
+    x = [TimeSpan(0, 10), TimeSpan(100, 200), TimeSpan(400, 1000)]
+    @test merge_spans((a, b) -> true, x) == [shortest_timespan_containing(x)]
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -15,6 +15,7 @@ using TimeSpans: contains, nanoseconds_per_sample
     @test stop(t) + Nanosecond(1) ∉ t
     @test shortest_timespan_containing([t]) == t
     @test shortest_timespan_containing((t,t,t)) == t
+    @test shortest_timespan_containing(t, t) == t
     @test duration(TimeSpan(start(t), stop(t) + Nanosecond(100))) == Nanosecond(101)
     @test duration(start(t)) == Nanosecond(1)
     @test_throws ArgumentError TimeSpan(4, 2)
@@ -67,6 +68,8 @@ end
     @test shortest_timespan_containing([TimeSpan(3, 7),
                                         TimeSpan(1, 10),
                                         TimeSpan(2, 5)]) == TimeSpan(1, 10)
+    @test shortest_timespan_containing(TimeSpan(1, 10),
+                                       TimeSpan(4, 20)) == TimeSpan(1, 20)
 end
 
 @testset "time <--> index conversion" begin


### PR DESCRIPTION
There are four distinct commits
1. Add a two-argument `shortest_timespan_containing` method. It's not uncommon to want merge exactly two `TimeSpan`s, but currently you have to wrap them in an interator in order to pass them to `shortest_timespan_containing`. This commit adds a method to the function that accepts two `TimeSpan`s and otherwise does what it says on the tin. It is only part of this PR because I wanted to use it to implement the other functions.
2. Define `merge_spans!(predicate, spans)`, which merges the timespans in `spans`, modifying and resizing it in-place.
3. Define `merge_spans(predicate, spans)` for an out-of-place analogue.
4. Bump the patch version.