### PR TITLE
Update CI to codecov-action v2

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -35,7 +35,7 @@ jobs:
       - uses: julia-actions/julia-runtest@v1
         continue-on-error: ${{ matrix.version == 'nightly' }}
       - uses: julia-actions/julia-processcoverage@v1
-      - uses: codecov/codecov-action@v1
+      - uses: codecov/codecov-action@v2
         with:
           file: lcov.info
   docs:


### PR DESCRIPTION
As mentioned in: https://github.com/codecov/codecov-action , codecov-action@v1 will be deprecated/sunset on February 1, 2022.

There are a few breaking changes mentioned in the codecov-action README.md, but I don't think this workflow uses any of the breaking changes mentioned.