### PR TITLE
add some more `index_from_time` tests

### DIFF
--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -114,7 +114,7 @@ end
     end
 
     for rate in (101//2, 1001//10, 200, 256, 1, 10)
-        for sample_time in (Nanosecond(12345), Minute(5), Nanosecond(Minute(5)) + Nanosecond(1), Nanosecond(1), Nanosecond(10^6))
+        for sample_time in (Nanosecond(12345), Minute(5), Nanosecond(Minute(5)) + Nanosecond(1), Nanosecond(1), Nanosecond(10^6), Nanosecond(6970297031))
             # compute with a very simple algorithm
             index = naive_index_from_time(rate, sample_time)
             # Check against our `TimeSpans.index_from_time`:

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -115,7 +115,12 @@ end
 
     for rate in (101//2, 1001//10, 200, 256, 1, 10)
         for sample_time in (Nanosecond(12345), Minute(5), Nanosecond(Minute(5)) + Nanosecond(1), Nanosecond(1), Nanosecond(10^6))
-            @test naive_index_from_time(rate, sample_time) == TimeSpans.index_from_time(rate, sample_time)
+            # compute with a very simple algorithm
+            index = naive_index_from_time(rate, sample_time)
+            # Check against our `TimeSpans.index_from_time`:
+            @test index == TimeSpans.index_from_time(rate, sample_time)
+            # Works even if `rate` is in Float64 precision:
+            @test index == TimeSpans.index_from_time(Float64(rate), sample_time)
         end
     end
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -4,7 +4,7 @@ using TimeSpans: contains, nanoseconds_per_sample
 
 function naive_index_from_time(sample_rate, sample_time)
     # This stepping computation is prone to roundoff error, so we'll work in high precision
-    sample_time_in_seconds = big(Dates.value(convert(Nanosecond, sample_time))) // big(TimeSpans.NS_IN_SEC)
+    sample_time_in_seconds = big(Dates.value(Nanosecond(sample_time))) // big(TimeSpans.NS_IN_SEC)
     # At time 0, we are at index 1
     t = Rational{BigInt}(0//1)
     index = 1
@@ -13,7 +13,7 @@ function naive_index_from_time(sample_rate, sample_time)
         t += 1 // sample_rate
         index += 1
         if t > sample_time_in_seconds
-            # we just passed it, so prevoius index is the last one before the time of interest
+            # we just passed it, so previous index is the last one before the time of interest
             return index - 1
         end
     end
@@ -114,16 +114,16 @@ end
     end
 
     for rate in (101//2, 1001//10, 200, 256, 1, 10)
-        for sample_time in (Nanosecond(12345), Minute(5), Nanosecond(Minute(5)) + Nanosecond(1), Nanosecond(1), Nanosecond(10^6), Nanosecond(6970297031))
+        for sample_time in (Nanosecond(12345), Minute(5), Nanosecond(Minute(5)) + Nanosecond(1),
+                            Nanosecond(1), Nanosecond(10^6), Nanosecond(6970297031))
             # compute with a very simple algorithm
             index = naive_index_from_time(rate, sample_time)
             # Check against our `TimeSpans.index_from_time`:
-            @test index == TimeSpans.index_from_time(rate, sample_time)
+            @test index == index_from_time(rate, sample_time)
             # Works even if `rate` is in Float64 precision:
-            @test index == TimeSpans.index_from_time(Float64(rate), sample_time)
+            @test index == index_from_time(Float64(rate), sample_time)
         end
     end
-
 end
 
 @testset "`in` and `findall`" begin


### PR DESCRIPTION
I was looking into https://github.com/beacon-biosignals/Onda.jl/pull/120 and was getting very confused. I started to doubt `TimeSpans.index_from_time`, so I wrote a test to compare to an extremely naive algorithm in exact arithmetic, to be sure the +1 was right and rounding wasn't causing an issue. As these tests show, our `index_from_time` seems perfectly fine (as expected probably 🙂). I figured they could still be useful to have here so others can be reassured as well (or me in the future,) and so we don't regress.