### PR TITLE
Backport features introduced in 0.3.x to 0.2.x

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -5,6 +5,7 @@ version = "0.2.6"
 
 [deps]
 Dates = "ade2ca70-3891-5945-98fb-dc099432e06a"
+Statistics = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
 
 [compat]
 julia = "1.6"

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "TimeSpans"
 uuid = "bb34ddd2-327f-4c4a-bfb0-c98fc494ece1"
 authors = ["Beacon Biosignals, Inc."]
-version = "0.2.6"
+version = "0.2.8"
 
 [deps]
 Dates = "ade2ca70-3891-5945-98fb-dc099432e06a"

--- a/src/TimeSpans.jl
+++ b/src/TimeSpans.jl
@@ -1,6 +1,7 @@
 module TimeSpans
 
 using Dates
+using Statistics
 
 export TimeSpan, start, stop, istimespan, translate, overlaps,
        shortest_timespan_containing, duration, index_from_time,
@@ -343,5 +344,12 @@ Return `merge_spans!(predicate, collect(spans))`.
 See also [`merge_spans!`](@ref).
 """
 merge_spans(predicate, spans) = merge_spans!(predicate, collect(spans))
+
+"""
+    Statistics.middle(t::TimeSpan, r::RoundingMode=RoundToZero)
+
+Return the midpoint of a TimeSpan in `Nanosecond`s.
+"""
+Statistics.middle(t::TimeSpan, r::RoundingMode=RoundToZero) = div(start(t) + stop(t), 2, r)
 
 end # module

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,6 +1,7 @@
 using Test, TimeSpans, Dates
 
 using TimeSpans: contains, nanoseconds_per_sample
+using Statistics
 
 @testset "basic TimeSpan code paths" begin
     t = TimeSpan(Nanosecond(rand(UInt32)))
@@ -133,4 +134,14 @@ end
                       (TimeSpan(0, 1), TimeSpan(4, 10))) == [TimeSpan(0, 10)]
     x = [TimeSpan(0, 10), TimeSpan(100, 200), TimeSpan(400, 1000)]
     @test merge_spans((a, b) -> true, x) == [shortest_timespan_containing(x)]
+end
+
+@testset "Statistics.middle" begin
+    @test middle(TimeSpan(Nanosecond(0), Nanosecond(2))) == Nanosecond(1)
+    @test middle(TimeSpan(Nanosecond(-1), Nanosecond(1))) == Nanosecond(0)
+    # rounding
+    @test middle(TimeSpan(Nanosecond(0), Nanosecond(1))) == Nanosecond(0)
+    @test middle(TimeSpan(Nanosecond(0), Nanosecond(1)), RoundUp) == Nanosecond(1)
+    @test middle(TimeSpan(Nanosecond(-1), Nanosecond(0))) == Nanosecond(0)
+    @test middle(TimeSpan(Nanosecond(-1), Nanosecond(0)), RoundDown) == Nanosecond(-1)
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -145,3 +145,44 @@ end
     @test middle(TimeSpan(Nanosecond(-1), Nanosecond(0))) == Nanosecond(0)
     @test middle(TimeSpan(Nanosecond(-1), Nanosecond(0)), RoundDown) == Nanosecond(-1)
 end
+
+@testset "invert_spans" begin
+    parent_span = TimeSpan(Second(0), Second(60))
+    # non-overlapping spans that extend to limits of parent_span
+    spans = [TimeSpan(Second(x), Second(x + 1)) for x in 0:10:59]
+    i_spans = invert_spans(spans, parent_span)
+    @test length(i_spans) == 6
+    @test all(duration.(i_spans) .== Second(9))
+    spans = [TimeSpan(Second(x + 8), Second(x + 10)) for x in 0:10:50]
+    i_spans = invert_spans(spans, parent_span)
+    @test length(i_spans) == 6
+    @test all(duration.(i_spans) .== Second(8))
+
+    # non-overlapping spans that do not extend to limits of parent_span
+    spans = [TimeSpan(Second(x + 1), Second(x + 2)) for x in 0:10:59]
+    i_spans = invert_spans(spans, parent_span)
+    @test length(i_spans) == 7
+    @test i_spans[1] == TimeSpan(Second(0), Second(1))
+    @test all(duration.(i_spans[2:6]) .== Second(9))
+    @test i_spans[end] == TimeSpan(Second(52), stop(parent_span))
+
+    # some spans lie outside of parent_span
+    i_spans = invert_spans(spans, TimeSpan(Second(0), Second(30)))
+    @test length(i_spans) == 4
+    @test maximum(stop, i_spans) <= Second(30)
+
+    # adjacent but not overlapping spans, unsorted
+    spans = vcat([TimeSpan(Second(x), Second(x + 1)) for x in 0:10:59],
+                 [TimeSpan(Second(x + 1), Second(x + 3)) for x in 0:10:59])
+    i_spans = invert_spans(spans, parent_span)
+    @test length(i_spans) == 6
+    @test all(duration.(i_spans) .== Second(7))
+
+    # overlapping, unsorted
+    spans = vcat([TimeSpan(Second(x), Second(x + 1)) for x in 0:10:59],
+                 [TimeSpan(Millisecond(x * 1000) + Millisecond(500), Second(x + 2))
+                  for x in 0:10:59])
+    i_spans = invert_spans(spans, parent_span)
+    @test length(i_spans) == 6
+    @test all(duration.(i_spans) .== Second(8))
+end


### PR DESCRIPTION
I've created a branch `release-0.2` that we can use for tagging further v0.2.x versions. That branch is the base branch of this PR. I've cherry-picked #24 and #36 and set the package version to v0.2.8.

IMO it would make sense to temporarily re-allow merge commits so as not to squash the individual cherry-picked commits but I don't think it matters too much. I can do the settings dance if folks agree.

Fixes #37.

---

For reference for those new to backporting, this is how I did this:
```bash
git checkout v0.2.7
git checkout -b release-0.2
git push origin release-0.2
git checkout -b aa/backport-v0.2
git cherry-pick -x -e bdd1e0200f727c2d59ddb90d30eb34c7495adc48  # PR 24
# Fixed conflict
git cherry-pick -x -e eb327966a96776b1b5f9980ad18e3719930d8279  # PR 36
# Set Project.toml version
git push origin aa/backport-v0.2
```
Any future PRs to create more v0.2.x versions can be made by:
```bash
git checkout -b xx/branch-name release-0.2
```
then opening a PR with `release-0.2` as the base branch.