### PR TITLE
Allow TimeSpans to be broadcasted (#43)

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "TimeSpans"
 uuid = "bb34ddd2-327f-4c4a-bfb0-c98fc494ece1"
 authors = ["Beacon Biosignals, Inc."]
-version = "0.2.8"
+version = "0.2.9"
 
 [deps]
 Dates = "ade2ca70-3891-5945-98fb-dc099432e06a"

--- a/src/TimeSpans.jl
+++ b/src/TimeSpans.jl
@@ -53,6 +53,9 @@ Base.in(x::TimePeriod, y::TimeSpan) = start(y) <= x < stop(y)
 Base.findall(pred::Base.Fix2{typeof(in), TimeSpan}, obj::AbstractArray) = invoke(findall, Tuple{Function, typeof(obj)}, pred, obj)
 Base.findall(pred::Base.Fix2{typeof(in), TimeSpan}, obj::Tuple) = invoke(findall, Tuple{Function, typeof(obj)}, pred, obj)
 
+# allow TimeSpans to be broadcasted
+Base.broadcastable(t::TimeSpan) = Ref(t)
+       
 #####
 ##### pretty printing
 #####

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -186,3 +186,13 @@ end
     @test length(i_spans) == 6
     @test all(duration.(i_spans) .== Second(8))
 end
+
+@testset "broadcast_spans" begin
+    test_vec = [TimeSpan(0, 100), TimeSpan(0, 200)]
+    test_vec .= TimeSpan(0, 300)
+    @test test_vec == [TimeSpan(0, 300), TimeSpan(0, 300)]
+
+    test_vec = []
+    test_vec .= TimeSpan(0, 300)
+    @test test_vec == []
+end


### PR DESCRIPTION
This is a backport of #43 to the release-0.2 branch! In summary, allows TimeSpans to be broadcasted without using `Ref()`.