### PR TITLE
Backport: Handle empty spans in `invert_spans`

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "TimeSpans"
 uuid = "bb34ddd2-327f-4c4a-bfb0-c98fc494ece1"
 authors = ["Beacon Biosignals, Inc."]
-version = "0.2.9"
+version = "0.2.10"
 
 [deps]
 Dates = "ade2ca70-3891-5945-98fb-dc099432e06a"

--- a/src/TimeSpans.jl
+++ b/src/TimeSpans.jl
@@ -363,6 +363,7 @@ Return a vector of `TimeSpan`s representing the gaps between the spans in the
 iterable `spans` that are contained within `parent_span`.
 """
 function invert_spans(spans, parent_span)
+    isempty(spans) && return [TimeSpan(parent_span)]
     spans = collect(spans)
     filter!(x -> contains(parent_span, x), spans)
     merge_spans!((a, b) -> start(b) <= stop(a), spans)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -185,6 +185,9 @@ end
     i_spans = invert_spans(spans, parent_span)
     @test length(i_spans) == 6
     @test all(duration.(i_spans) .== Second(8))
+
+    # empty
+    @test invert_spans(TimeSpan[], parent_span) == [parent_span]
 end
 
 @testset "broadcast_spans" begin


### PR DESCRIPTION
(cherry picked from commit 97d628fc2670de382b459f3fd3e565122c3ab649, PR #48)