### PR TITLE
use 64-bit precision for nanoseconds_per_sample

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "TimeSpans"
 uuid = "bb34ddd2-327f-4c4a-bfb0-c98fc494ece1"
 authors = ["Beacon Biosignals, Inc."]
-version = "0.3.4"
+version = "0.3.5"
 
 [deps]
 Dates = "ade2ca70-3891-5945-98fb-dc099432e06a"

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "TimeSpans"
 uuid = "bb34ddd2-327f-4c4a-bfb0-c98fc494ece1"
 authors = ["Beacon Biosignals, Inc."]
-version = "0.3.3"
+version = "0.3.4"
 
 [deps]
 Dates = "ade2ca70-3891-5945-98fb-dc099432e06a"

--- a/src/TimeSpans.jl
+++ b/src/TimeSpans.jl
@@ -191,7 +191,7 @@ Given `sample_rate` in Hz, return the number of nanoseconds corresponding to one
 Note that this function performs the relevant calculation using `Float64(sample_rate)`
 in order to improve the accuracy of the result.
 """
-nanoseconds_per_sample(sample_rate) = inv(Float64(sample_rate)) * NS_IN_SEC
+nanoseconds_per_sample(sample_rate) = NS_IN_SEC / Float64(sample_rate)
 
 """
     index_from_time(sample_rate, sample_time::Period)

--- a/src/TimeSpans.jl
+++ b/src/TimeSpans.jl
@@ -55,7 +55,7 @@ Base.findall(pred::Base.Fix2{typeof(in), TimeSpan}, obj::Tuple) = invoke(findall
 
 # allow TimeSpans to be broadcasted
 Base.broadcastable(t::TimeSpan) = Ref(t)
-       
+
 #####
 ##### pretty printing
 #####
@@ -187,8 +187,11 @@ duration(span) = stop(span) - start(span)
     TimeSpans.nanoseconds_per_sample(sample_rate)
 
 Given `sample_rate` in Hz, return the number of nanoseconds corresponding to one sample.
+
+Note that this function performs the relevant calculation using `Float64(sample_rate)`
+in order to improve the accuracy of the result.
 """
-nanoseconds_per_sample(sample_rate) = inv(sample_rate) * NS_IN_SEC
+nanoseconds_per_sample(sample_rate) = inv(Float64(sample_rate)) * NS_IN_SEC
 
 """
     index_from_time(sample_rate, sample_time::Period)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -125,16 +125,7 @@ end
             @test index == index_from_time(Float64(rate), sample_time)
         end
     end
-end
 
-@testset "`in` and `findall`" begin
-    @test findall(in(TimeSpan(1, 10)), Nanosecond.(5:15)) == 1:5
-    @test findall(in(TimeSpan(1, 10)), map(Nanosecond, (9,10,11))) == 1:1
-    @test in(TimeSpan(1,2))(Nanosecond(1))
-    @test !in(TimeSpan(1,2))(Nanosecond(2))
-end
-
-@testset "index_from_time" begin
     @testset "docstring" begin
         @test index_from_time(1, Second(0)) == 1
         @test index_from_time(1, Second(1)) == 2
@@ -147,7 +138,16 @@ end
         @test index_from_time(200, ns) == 30001
         @test index_from_time(200e0, ns) == 30001
         @test index_from_time(200f0, ns) == 30001
+        @test time_from_index(143.5, 8611) == Nanosecond(60000000000)
+        @test time_from_index(Float32(143.5), 8611) == Nanosecond(60000000000)
     end
+end
+
+@testset "`in` and `findall`" begin
+    @test findall(in(TimeSpan(1, 10)), Nanosecond.(5:15)) == 1:5
+    @test findall(in(TimeSpan(1, 10)), map(Nanosecond, (9,10,11))) == 1:1
+    @test in(TimeSpan(1,2))(Nanosecond(1))
+    @test !in(TimeSpan(1,2))(Nanosecond(2))
 end
 
 @testset "merge_spans!" begin


### PR DESCRIPTION
also moves some tests to the appropriate code block

there is an argument to be made that the caller "chose" Float32 so we should respect the numerical conclusions that arise from that, but it seems a bit unreasonable to expect callers to be able to predict the implications in this case
