### PR TITLE
improve consistency of time <-> index conversion

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "TimeSpans"
 uuid = "bb34ddd2-327f-4c4a-bfb0-c98fc494ece1"
 authors = ["Beacon Biosignals, Inc."]
-version = "0.3.3"
+version = "0.3.4"
 
 [deps]
 Dates = "ade2ca70-3891-5945-98fb-dc099432e06a"

--- a/src/TimeSpans.jl
+++ b/src/TimeSpans.jl
@@ -8,7 +8,6 @@ export TimeSpan, start, stop, istimespan, translate, overlaps,
        shortest_timespan_containing, duration, index_from_time,
        time_from_index, merge_spans!, merge_spans, invert_spans
 
-
 const NS_IN_SEC = Dates.value(Nanosecond(Second(1)))  # Number of nanoseconds in one second
 
 #####
@@ -213,15 +212,11 @@ julia> index_from_time(100, Millisecond(1000))
 101
 ```
 """
-index_from_time(sample_rate, sample_time::Period) = first(index_and_is_rounded_from_time(sample_rate, sample_time))
-
-# Helper to get the index and whether or not it has been rounded
-function index_and_is_rounded_from_time(sample_rate, sample_time::Period)
+function index_from_time(sample_rate, sample_time::Period)
     time_in_nanoseconds = convert(Nanosecond, sample_time).value
     time_in_nanoseconds >= 0 || throw(ArgumentError("`sample_time` must be >= 0 nanoseconds"))
     time_in_seconds = time_in_nanoseconds / NS_IN_SEC
-    index = time_in_seconds * sample_rate + 1
-    return floor(Int, index), !isinteger(index)
+    return floor(Int, time_in_seconds * sample_rate) + 1
 end
 
 """
@@ -242,12 +237,7 @@ julia> index_from_time(100, TimeSpan(Second(3), Second(6)))
 """
 function index_from_time(sample_rate, span)
     i = index_from_time(sample_rate, start(span))
-    j, is_rounded = index_and_is_rounded_from_time(sample_rate, stop(span))
-    # if `j` has been rounded down, then we are already excluding the right endpoint
-    # by means of that rounding. Hence, we don't need to decrement here.
-    if i != j && !is_rounded
-        j -= 1
-    end
+    j = index_from_time(sample_rate, stop(span) - Nanosecond(1))
     return i:j
 end
 
@@ -281,7 +271,12 @@ end
 """
     time_from_index(sample_rate, sample_range::AbstractUnitRange)
 
-Return the `TimeSpan` corresponding to `sample_range` given `sample_rate` in Hz:
+Return the `TimeSpan` corresponding to `sample_range` given `sample_rate` in Hz.
+
+Note that the returned span includes the time period between the final sample and
+its successor, excluding the successor itself.
+
+Examples:
 
 ```jldoctest
 julia> time_from_index(100, 1:100)
@@ -296,9 +291,8 @@ TimeSpan(3000000000 nanoseconds, 6000000000 nanoseconds)
 """
 function time_from_index(sample_rate, sample_range::AbstractUnitRange)
     i, j = first(sample_range), last(sample_range)
-    j = j == i ? j : j + 1
     return TimeSpan(time_from_index(sample_rate, i),
-                    time_from_index(sample_rate, j))
+                    time_from_index(sample_rate, j + 1))
 end
 
 """

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -94,7 +94,7 @@ end
     @test_throws ArgumentError time_from_index(200, 0)
     @test time_from_index(100, 1) == Nanosecond(0)
     @test time_from_index(100, 301:600) == TimeSpan(Second(3), Second(6))
-    @test time_from_index(100, 101:101) == TimeSpan(Second(1))
+    @test time_from_index(100, 101:101) == TimeSpan(Second(1), Nanosecond(1010000000))
     @test_throws ArgumentError index_from_time(200, Nanosecond(-1))
     @test index_from_time(100, Nanosecond(0)) == 1
     @test index_from_time(100, TimeSpan(Second(3), Second(6))) == 301:600
@@ -147,6 +147,10 @@ end
         @test index_from_time(200, ns) == 30001
         @test index_from_time(200e0, ns) == 30001
         @test index_from_time(200f0, ns) == 30001
+    end
+
+    for i in 1:10
+        @test index_from_time(1.5, time_from_index(1.5, 1:i)) == 1:i
     end
 end
 


### PR DESCRIPTION
I'm working on upgrading Onda.jl and in the process trying to tackle https://github.com/beacon-biosignals/Onda.jl/issues/123, but running into problems because of behaviors similar to this:

```jl
julia> index_from_time(1.5, time_from_index(1.5, 1:5))
1:6

julia> index_from_time(1.5, time_from_index(1.5, 1:6))
1:6
```

this PR basically is an attempt to make a more holistic/consistent fix for the kind of bug that #29 was trying to fix, namely incorrect values due to the erroneous inclusion/consideration of the `span`'s "excluded" upper bound

similarly makes `time_from_index` more consistent

I don't view this as a breaking change as much as a continuation of the bug fix in #29 , but if folks want to see a bump to v0.4 here I can do so