### PR TITLE
Allow spans that cross the parent's boundary in `invert_spans`

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "TimeSpans"
 uuid = "bb34ddd2-327f-4c4a-bfb0-c98fc494ece1"
 authors = ["Beacon Biosignals, Inc."]
-version = "0.3.5"
+version = "0.3.6"
 
 [deps]
 Dates = "ade2ca70-3891-5945-98fb-dc099432e06a"

--- a/src/TimeSpans.jl
+++ b/src/TimeSpans.jl
@@ -375,7 +375,7 @@ iterable `spans` that are contained within `parent_span`.
 function invert_spans(spans, parent_span)
     isempty(spans) && return [TimeSpan(parent_span)]
     spans = collect(spans)
-    filter!(x -> contains(parent_span, x), spans)
+    filter!(x -> overlaps(x, parent_span), spans)
     merge_spans!((a, b) -> start(b) <= stop(a), spans)
     gaps = TimeSpan[]
     previous_span = first(spans)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -227,6 +227,10 @@ end
 
     # empty
     @test invert_spans(TimeSpan[], parent_span) == [parent_span]
+
+    # some spans cross the parent span's boundary
+    i_spans = invert_spans([TimeSpan(-5, 3), TimeSpan(6, 8)], TimeSpan(0, 10))
+    @test i_spans == [TimeSpan(3, 6), TimeSpan(8, 10)]
 end
 
 @testset "broadcast_spans" begin


### PR DESCRIPTION
Fixes #52.