### PR TITLE
Add a package extension for ArrowTypes

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -20,6 +20,7 @@ Compat = "3.38, 4"
 julia = "1.6"
 
 [extras]
+ArrowTypes = "31f734f8-188a-4ce0-8406-c8a06bd891cd"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]

--- a/Project.toml
+++ b/Project.toml
@@ -21,6 +21,7 @@ Compat = "3.38, 4"
 julia = "1.6"
 
 [extras]
+ArrowTypes = "31f734f8-188a-4ce0-8406-c8a06bd891cd"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]

--- a/Project.toml
+++ b/Project.toml
@@ -1,19 +1,26 @@
 name = "TimeSpans"
 uuid = "bb34ddd2-327f-4c4a-bfb0-c98fc494ece1"
 authors = ["Beacon Biosignals, Inc."]
-version = "1.0.0"
+version = "1.1.0"
 
 [deps]
 Compat = "34da2185-b29b-5c13-b0c7-acf172513d20"
 Dates = "ade2ca70-3891-5945-98fb-dc099432e06a"
 Statistics = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
 
+[weakdeps]
+ArrowTypes = "31f734f8-188a-4ce0-8406-c8a06bd891cd"
+
+[extensions]
+TimeSpansArrowTypesExt = "ArrowTypes"
+
 [compat]
-Compat = "3.38,4"
+ArrowTypes = "2"
+Compat = "3.38, 4"
 julia = "1.6"
 
 [extras]
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
-test = ["Test"]
+test = ["ArrowTypes", "Test"]

--- a/Project.toml
+++ b/Project.toml
@@ -4,6 +4,7 @@ authors = ["Beacon Biosignals, Inc."]
 version = "1.1.0"
 
 [deps]
+ArrowTypes = "31f734f8-188a-4ce0-8406-c8a06bd891cd"
 Compat = "34da2185-b29b-5c13-b0c7-acf172513d20"
 Dates = "ade2ca70-3891-5945-98fb-dc099432e06a"
 Statistics = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
@@ -20,7 +21,6 @@ Compat = "3.38, 4"
 julia = "1.6"
 
 [extras]
-ArrowTypes = "31f734f8-188a-4ce0-8406-c8a06bd891cd"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]

--- a/ext/TimeSpansArrowTypesExt.jl
+++ b/ext/TimeSpansArrowTypesExt.jl
@@ -1,0 +1,11 @@
+module TimeSpansArrowTypesExt
+
+using ArrowTypes
+using TimeSpans
+
+const TIME_SPAN_ARROW_NAME = Symbol("JuliaLang.TimeSpan")
+
+ArrowTypes.arrowname(::Type{TimeSpan}) = TIME_SPAN_ARROW_NAME
+ArrowTypes.JuliaType(::Val{TIME_SPAN_ARROW_NAME}) = TimeSpan
+
+end

--- a/src/TimeSpans.jl
+++ b/src/TimeSpans.jl
@@ -399,4 +399,12 @@ function invert_spans(spans, parent_span)
     return gaps
 end
 
+#####
+##### Package extensions (TODO: remove this section once we require Julia 1.9+)
+#####
+
+if !isdefined(Base, :get_extension)
+    include(joinpath(dirname(@__DIR__), "ext", "TimeSpansArrowTypesExt.jl"))
+end
+
 end # module

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -263,3 +263,10 @@ end
     test_vec .= TimeSpan(0, 300)
     @test test_vec == []
 end
+
+@testset "extensions" begin
+    @testset "ArrowTypes" begin
+        using ArrowTypes
+        @test ArrowTypes.JuliaType(Val(ArrowTypes.arrowname(TimeSpan))) === TimeSpan
+    end
+end


### PR DESCRIPTION
Onda currently defines ArrowTypes methods for `TimeSpan`, likely a holdover from before TimeSpans was its own package. The ArrowTypes interoperability should instead be managed here, and we can do that using a package extension.

I tried to make this compatible with Julia 1.6 but I don't know whether that was successful; CI will tell us.